### PR TITLE
add web sequence diagrams API

### DIFF
--- a/monitor/client/.gitignore
+++ b/monitor/client/.gitignore
@@ -19,3 +19,6 @@
 npm-debug.log*
 yarn-debug.log*
 yarn-error.log*
+
+logs.txt
+logs.png

--- a/monitor/client/package-lock.json
+++ b/monitor/client/package-lock.json
@@ -10864,6 +10864,14 @@
         "source-map": "0.6.1"
       }
     },
+    "websequencediagrams": {
+      "version": "0.1.1",
+      "resolved": "https://registry.npmjs.org/websequencediagrams/-/websequencediagrams-0.1.1.tgz",
+      "integrity": "sha512-Vy5K6bUUJv61PuOj6tsHrwNzq4Cl0CBznVsi0tpuWoGfLGOhXZOs7vCZTnxJqvr5Icj0PfSDdSJWXGtMyRZ1IA==",
+      "requires": {
+        "optimist": "0.6.1"
+      }
+    },
     "websocket-driver": {
       "version": "0.7.0",
       "resolved": "https://registry.npmjs.org/websocket-driver/-/websocket-driver-0.7.0.tgz",

--- a/monitor/client/package.json
+++ b/monitor/client/package.json
@@ -9,7 +9,8 @@
     "react-scripts": "1.1.4",
     "socket.io": "^2.1.1",
     "socket.io-client": "^2.1.1",
-    "three": "^0.96.0"
+    "three": "^0.96.0",
+    "websequencediagrams": "^0.1.1"
   },
   "scripts": {
     "start": "react-scripts start",

--- a/monitor/client/public/index.html
+++ b/monitor/client/public/index.html
@@ -22,6 +22,5 @@
     <script src="js/adminlte.min.js"></script>
     <script src="https://use.fontawesome.com/581d5d54d2.js"></script>
     <script src="//cdnjs.cloudflare.com/ajax/libs/socket.io/2.1.1/socket.io.slim.js"></script>
-    <script type="text/javascript" src="http://www.websequencediagrams.com/service.js"></script>
   </body>
 </html>

--- a/monitor/client/wsd.js
+++ b/monitor/client/wsd.js
@@ -1,0 +1,14 @@
+var wsd = require('websequencediagrams');
+var fs = require('fs');
+
+const text = fs.readFileSync('./logs.txt', 'utf8');
+console.log(`file contents:\n${text}`);
+
+wsd.diagram(text, "earth", "png", function (err, buf, typ) {
+    if (err) {
+        console.error(err);
+    } else {
+        console.log("Received MIME type:", typ);
+        fs.writeFile("logs.png", buf);
+    }
+});


### PR DESCRIPTION
## 目的
シーケンス図を作成するためのAPIを導入する

## 変更点
* npm install websequencediagrams
* 実行ファイル wsd.js を作成
* GetJson() 内に API に POST するテキストを生成するコードを追加
* monitor-client.go を go fmt
* index.html から不要な箇所を削除
* gitignore の更新

## 実行方法
1. `cd synerex_alpha/monitor/client/`
1. `node wsd.js`
1. logs.png が作成される

## 今後
テキストファイルを経由せずに socket.io で 処理させる

## 関連URL
* https://www.websequencediagrams.com/embedding.html
* https://www.npmjs.com/package/websequencediagrams