### PR TITLE
Issue/kota onemile marketing

### DIFF
--- a/provider/onemile/onemile-provider.go
+++ b/provider/onemile/onemile-provider.go
@@ -446,6 +446,9 @@ func runSocketIOServer(rdClient, mktClient *sxutil.SMServiceClient) {
 				dispMap[taxi] = &display{dispId: disp, socket: so, wg: sync.WaitGroup{}}
 				log.Printf("Register display [taxi: %s => display: %v]\n", taxi, dispMap[taxi])
 				dispWg.Done()
+			} else {
+				dispMap[taxi].socket = so
+				log.Printf("Update display [taxi: %s, display: %v]\n", taxi, dispMap[taxi])
 			}
 		})
 


### PR DESCRIPTION
onemile-display-clientも再接続可能にしました。
ディスプレイ側は保存すべき情報がないので、socketのみを更新しています。
